### PR TITLE
Add muon download to the download page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,13 +27,14 @@
       <li><a href="ubuntu.html">Ubuntu</a></li>
       <li><a href="windows.html">Windows</a></li>
     </ul>
-    <div class="windows-upgrade admonition warning">
+    <div class="windows admonition warning">
       <p>Windows 7/8 users: if you see the following error:</p>
       <img style="display: block; margin-left: auto; margin-right: auto;" src="img/msvc2015-dll.png" width="300px">
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
+    </div>
     <div class="windows">
-      <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe"> Muon users please use this download for Mantid </a> <p>
+      <p>Muon users please use <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe">this</a> download for Mantid</p>       
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
     <div class="windows">
-      <a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows"> Muon users please use this download for Mantid </a> <p>
+      <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe"> Muon users please use this download for Mantid </a> <p>
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,8 @@
       <img style="display: block; margin-left: auto; margin-right: auto;" src="img/msvc2015-dll.png" width="300px">
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
+    <div class="windows">
+      <a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows"> Muon users please use this download for Mantid </a> <p>
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -28,6 +28,7 @@ $(document).ready(function() {
   os = getOS();
   updateInstructionsURL(os);
   winUpgradeWarning = $(".windows-upgrade");
+  windows = $(".windows");
   // Show source code download for Linux distros.
   if (os == "Linux")
   {
@@ -36,7 +37,8 @@ $(document).ready(function() {
     $('#paraview .button').attr("href",$("#paraview .Source").attr("href")).text("Download source code")
 
     $(".Source").closest('li').remove();
-    winUpgradeWarning.hide()
+    winUpgradeWarning.hide();
+    windows.hide();
   }
   else
   {
@@ -47,7 +49,10 @@ $(document).ready(function() {
     $('#paraview .button').attr("href",$("#paraview " + osClass).attr("href"));
 
     $(osClass).closest('li').remove();
-    if (os == "Windows") winUpgradeWarning.show();
+    if (os == "Windows"){
+            winUpgradeWarning.show();
+            windows.show();
+    }
     else winUpgradeWarning.hide();
 
   }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -27,7 +27,6 @@ $(document).ready(function() {
   windowsXPWarning()
   os = getOS();
   updateInstructionsURL(os);
-  winUpgradeWarning = $(".windows-upgrade");
   windows = $(".windows");
   // Show source code download for Linux distros.
   if (os == "Linux")
@@ -37,7 +36,6 @@ $(document).ready(function() {
     $('#paraview .button').attr("href",$("#paraview .Source").attr("href")).text("Download source code")
 
     $(".Source").closest('li').remove();
-    winUpgradeWarning.hide();
     windows.hide();
   }
   else
@@ -50,10 +48,9 @@ $(document).ready(function() {
 
     $(osClass).closest('li').remove();
     if (os == "Windows"){
-            winUpgradeWarning.show();
             windows.show();
     }
-    else winUpgradeWarning.hide();
+    else windows.hide();
 
   }
 });

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -17,6 +17,8 @@
       <img style="display: block; margin-left: auto; margin-right: auto;" src="img/msvc2015-dll.png" width="300px">
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
+    <div class="windows">
+      <a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows"> Muon users please use this download for Mantid </a> <p>
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -12,13 +12,14 @@
     <ul class="instructions">{% for instruction in instructions %}
       <li><a href="{{instruction.replace("-", "").lower() ~ '.html' }}">{{ instruction.replace("-", " ") }}</a></li>{% endfor %}
     </ul>
-    <div class="windows-upgrade admonition warning">
+    <div class="windows admonition warning">
       <p>Windows 7/8 users: if you see the following error:</p>
       <img style="display: block; margin-left: auto; margin-right: auto;" src="img/msvc2015-dll.png" width="300px">
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
+    </div>
     <div class="windows">
-      <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe"> Muon users please use this download for Mantid </a> <p>
+      <p>Muon users please use <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe">this</a> download for Mantid.</p>       
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -18,7 +18,7 @@
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
     <div class="windows">
-      <a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows"> Muon users please use this download for Mantid </a> <p>
+      <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe"> Muon users please use this download for Mantid </a> <p>
     </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>


### PR DESCRIPTION
The muon group had some bugs that they wanted fixing. The recent nightly contains all of the fixes that they want. Therefore, we have added a new link to the mantid download page for muon users that points to the nightly (3rd Jan). 