### PR TITLE
added muon links back in as muon analysis broke

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,9 @@
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
     </div>
+    <div class="windows">
+      <p>Muon users please use <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe">this</a> download for Mantid.</p>       
+    </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>
     <ul class="alternatives">

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -18,6 +18,9 @@
       <p>your machine has not had recent Windows updates applied. Please either update Windows fully or install the relevant
 	<a href="https://support.microsoft.com/en-gb/help/2999226/update-for-universal-c-runtime-in-windows">standalone</a> update package for your version of x64 Windows.</p>
     </div>
+    <div class="windows">
+       <p>Muon users please use <a href="http://files.mantidproject.org/kits/muon/3.11-fix/mantid-3.11.20180103.1049-win64.exe">this</a> download for Mantid.</p>       
+    </div>
     <a href="#" class="button">Download Mantid for </a>
     <p>Alternative downloads:</p>
     <ul class="alternatives">{% for osname,buildinfo in latest_release['build_info']|dictsort() %}


### PR DESCRIPTION
Since muon analysis is broken it has been decided that we should put the muon download link back in (to the previous good nightly 3rd Jan). Then once a fix is complete we can update the nightly. 