### PR TITLE
Fix run instructs for nightly build on ubuntu

### DIFF
--- a/instructions/Ubuntu.rst
+++ b/instructions/Ubuntu.rst
@@ -40,7 +40,7 @@ and then install package with: ::
 
 This will install Mantid into ``/opt/mantidnightly``. It does **not** update the environment so you must type the following to start it: ::
 
-    ./opt/mantidnightly/bin/MantidPlot
+    /opt/mantidnightly/bin/launch_mantidplot.sh
 
 This is to avoid users accidentally running the nightly development build.
 

--- a/instructions/Ubuntu.rst
+++ b/instructions/Ubuntu.rst
@@ -40,7 +40,7 @@ and then install package with: ::
 
 This will install Mantid into ``/opt/mantidnightly``. It does **not** update the environment so you must type the following to start it: ::
 
-    /opt/mantidnightly/bin/launch_mantidplot.sh
+    /opt/mantidnightly/bin/MantidPlot
 
 This is to avoid users accidentally running the nightly development build.
 


### PR DESCRIPTION
Closes #13

Updated the run instructions for the nightly build on Ubuntu to run from the launch script.