### PR TITLE
Set next release on macOS to High Sierra

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = pep8
+column_limit = 100
+allow_split_before_dict_value = false
+each_dict_entry_on_separate_line = true

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -13,14 +13,15 @@ from six import iteritems
 
 # Repo folder structure
 ROOT_DIR = os.path.join(os.path.dirname(__file__), "..")
-RELEASE_DIR = os.path.join(ROOT_DIR,"releases")
+RELEASE_DIR = os.path.join(ROOT_DIR, "releases")
 PARAVIEW_DIR = os.path.join(RELEASE_DIR, "paraview")
 INSTRUCTIONS_DIR = os.path.join(ROOT_DIR, "instructions")
 
 NIGHTLY_NAME_SUFFIX = "nightly"
 
 # Parse date of nightly build
-NIGHTLY_DATE_RE = re.compile(r'^(?:mantidnightly|mantid)(?:-|_)(?:\d+)\.(?:\d+)\.(\d{8})\.(?:\d{3,4})-.*$')
+NIGHTLY_DATE_RE = re.compile(
+    r'^(?:mantidnightly|mantid)(?:-|_)(?:\d+)\.(?:\d+)\.(\d{8})\.(?:\d{3,4})-.*$')
 
 # General globals
 MANTID_NEWS = "http://developer.mantidproject.org/"
@@ -37,28 +38,33 @@ SOURCEFORGE_PARAVIEW = SOURCEFORGE_FILES + "ParaView/"
 SOURCEFORGE_IPYTHON_NOTEBOOK = SOURCEFORGE_FILES + "IPython%20Notebook/"
 
 # Must be in the name : downloadurl format.
-SAMPLES_DATASETS = [
-  ["Usage Examples", SOURCEFORGE_SAMPLES + "UsageData.zip/download"],
-  ["ISIS", SOURCEFORGE_SAMPLES + "SampleData-ISIS.zip/download"],
-  ["ORNL", SOURCEFORGE_SAMPLES + "SampleData-ORNL.zip/download"],
-  ["Muon", SOURCEFORGE_SAMPLES + "SampleData-Muon.zip/download"],
-  ["Training", SOURCEFORGE_SAMPLES + "TrainingCourseData.zip/download"]
-]
+SAMPLES_DATASETS = [["Usage Examples", SOURCEFORGE_SAMPLES + "UsageData.zip/download"],
+                    ["ISIS", SOURCEFORGE_SAMPLES + "SampleData-ISIS.zip/download"],
+                    ["ORNL", SOURCEFORGE_SAMPLES + "SampleData-ORNL.zip/download"],
+                    ["Muon", SOURCEFORGE_SAMPLES + "SampleData-Muon.zip/download"],
+                    ["Training", SOURCEFORGE_SAMPLES + "TrainingCourseData.zip/download"]]
 
-IPYTHON_NOTEBOOK = [
-  ["IPython Notebook Example", SOURCEFORGE_IPYTHON_NOTEBOOK + "Introduction%20to%20using%20Mantid%20with%20IPython%20Notebook.ipynb/download" ]
-]
+IPYTHON_NOTEBOOK = [[
+    "IPython Notebook Example", SOURCEFORGE_IPYTHON_NOTEBOOK +
+    "Introduction%20to%20using%20Mantid%20with%20IPython%20Notebook.ipynb/download"
+]]
 
 OSX_CODENAME_VERSIONS = {
-  'SnowLeopard': '10.6', 'Lion': '10.7',
-  'MountainLion': '10.8', 'Mavericks': '10.9',
-  'Yosemite': '10.10', 'ElCapitan': '10.11',
-  'Sierra': '10.12', 'HighSierra': '10.13',
-  'Mojave': '10.14', 'Catalina': '10.15'
+    'SnowLeopard': '10.6',
+    'Lion': '10.7',
+    'MountainLion': '10.8',
+    'Mavericks': '10.9',
+    'Yosemite': '10.10',
+    'ElCapitan': '10.11',
+    'Sierra': '10.12',
+    'HighSierra': '10.13',
+    'Mojave': '10.14',
+    'Catalina': '10.15'
 }
 
+
 def mantid_releases():
-  """
+    """
   Reads and stores release information for each release file in the releases folder. This does not include the nightly build.
 
   Returns:
@@ -80,30 +86,35 @@ def mantid_releases():
       ...
     ]
   """
-  releases = []
-  release_files = [name for name in os.listdir(RELEASE_DIR) if "paraview" not in name and NIGHTLY_NAME_SUFFIX not in name]
-  for file_name in release_files:
-    release = {}
-    release['mantid_version'] = os.path.splitext(file_name)[0]
-    release["mantid_formatted_version"] = format_release_str(release['mantid_version'])
-    release['paraview_version'] = paraview_version(release['mantid_version'])
-    date, mantid_builds = parse_build_names(os.path.join(RELEASE_DIR, file_name), release['mantid_version'], "release")
-    release['date'] = date
-    pv_version = release['paraview_version']
-    paraview_builds = paraview_build_names(pv_version) if pv_version is not None else {}
-    if len(paraview_builds) > 0:
-      for osname, info in iteritems(paraview_builds):
-        try:
-          mantid_builds[osname]['paraview_url'] = paraview_builds[osname]
-        except KeyError:
-          pass
+    releases = []
+    release_files = [
+        name for name in os.listdir(RELEASE_DIR)
+        if "paraview" not in name and NIGHTLY_NAME_SUFFIX not in name
+    ]
+    for file_name in release_files:
+        release = {}
+        release['mantid_version'] = os.path.splitext(file_name)[0]
+        release["mantid_formatted_version"] = format_release_str(release['mantid_version'])
+        release['paraview_version'] = paraview_version(release['mantid_version'])
+        date, mantid_builds = parse_build_names(os.path.join(RELEASE_DIR, file_name),
+                                                release['mantid_version'], "release")
+        release['date'] = date
+        pv_version = release['paraview_version']
+        paraview_builds = paraview_build_names(pv_version) if pv_version is not None else {}
+        if len(paraview_builds) > 0:
+            for osname, info in iteritems(paraview_builds):
+                try:
+                    mantid_builds[osname]['paraview_url'] = paraview_builds[osname]
+                except KeyError:
+                    pass
 
-    release['build_info'] = mantid_builds
-    releases.append(release)
-  return sorted(releases, key=lambda k : k['date'],reverse=True)
+        release['build_info'] = mantid_builds
+        releases.append(release)
+    return sorted(releases, key=lambda k: k['date'], reverse=True)
+
 
 def parse_build_names(file_location, version, build_option):
-  """
+    """
   Parses a file that contains build names (e.g. those in /releases/) and stores the contents in a dictionary.
   The key of the dictionary is the operating system, which is obtained based on the build's file extension.
   The date on the first line is optional, if it is not present the date is extracted from the first filename if
@@ -119,35 +130,40 @@ def parse_build_names(file_location, version, build_option):
            Key : Obtained from get_os, and is output on the downloads page as CSS classes.
            Value : The download url for that specific operating system.
   """
-  manifest = open(file_location, 'r')
-  date = None
-  if build_option is not NIGHTLY_NAME_SUFFIX:
-    try:
-        first_line = manifest.readline().rstrip()
-        datetime.datetime.strptime(first_line, "%Y-%m-%d")
-        date = first_line
-    except ValueError:
-        raise RuntimeError("Expected date stamp to be found on first line of release file. Found: "
-                           + first_line)
+    manifest = open(file_location, 'r')
+    date = None
+    if build_option is not NIGHTLY_NAME_SUFFIX:
+        try:
+            first_line = manifest.readline().rstrip()
+            datetime.datetime.strptime(first_line, "%Y-%m-%d")
+            date = first_line
+        except ValueError:
+            raise RuntimeError(
+                "Expected date stamp to be found on first line of release file. Found: " +
+                first_line)
 
-  builds = {}
-  for line in manifest:
-    build = line.rstrip()
-    if build == "":
-      continue
+    builds = {}
+    for line in manifest:
+        build = line.rstrip()
+        if build == "":
+            continue
 
-    os_info = get_os(build)
-    if date is None:
-      build_date = get_date_from_nightly(build)
-    else:
-      build_date = date
-    builds[os_info[0]] = {'url': get_download_url(build,version,build_option), 'type': os_info[1],
-                          'date': build_date}
-  #endfor
-  return (date, builds)
+        os_info = get_os(build)
+        if date is None:
+            build_date = get_date_from_nightly(build)
+        else:
+            build_date = date
+        builds[os_info[0]] = {
+            'url': get_download_url(build, version, build_option),
+            'type': os_info[1],
+            'date': build_date
+        }
+    #endfor
+    return (date, builds)
+
 
 def paraview_version(mantid_version):
-  """
+    """
   Obtains the paraview version for a specific mantid release from the paraview versions file.
 
   Args:
@@ -156,16 +172,17 @@ def paraview_version(mantid_version):
   Returns:
     str: The paraview version that the given release of mantid requires.
   """
-  with open(os.path.join(PARAVIEW_DIR, "paraviewVersions.txt"), "r") as paraviewReleases:
-    for line in paraviewReleases:
-      m_version, paraview_version = line.rstrip("\n").split(",")
-      if m_version == mantid_version:
-        return paraview_version
-      else:
-        return None
+    with open(os.path.join(PARAVIEW_DIR, "paraviewVersions.txt"), "r") as paraviewReleases:
+        for line in paraviewReleases:
+            m_version, paraview_version = line.rstrip("\n").split(",")
+            if m_version == mantid_version:
+                return paraview_version
+            else:
+                return None
+
 
 def paraview_build_names(paraview_version):
-  """
+    """
   Reads and stores paraview build names from the paraview release file, which is parsed based on version.
 
   Args:
@@ -174,11 +191,12 @@ def paraview_build_names(paraview_version):
   Returns:
     dict: The paraview build names for the given version.
   """
-  file_location = os.path.join(PARAVIEW_DIR, "paraview-" + paraview_version + ".txt")
-  return parse_build_names(file_location, paraview_version, "paraview")[1]
+    file_location = os.path.join(PARAVIEW_DIR, "paraview-" + paraview_version + ".txt")
+    return parse_build_names(file_location, paraview_version, "paraview")[1]
+
 
 def nightly_release():
-  """
+    """
   Reads and stores release information for the nightly build from the nightly text file in the releases folder.
   The date on the first line is optional, if it is not present the date is extracted from the first filename.
 
@@ -186,17 +204,19 @@ def nightly_release():
     dict: A dictionary containing release information for the nightly build.
     A similar format (see inner dict) of mantid_releases above is returned.
   """
-  release_info = {}
-  filename = [name for name in os.listdir(RELEASE_DIR) if NIGHTLY_NAME_SUFFIX in name]
-  release_info['version'] = os.path.splitext(filename[0])[0]
-  date, builds = parse_build_names(os.path.join(RELEASE_DIR,filename[0]),release_info['version'],NIGHTLY_NAME_SUFFIX)
-  release_info['date'] = date
-  release_info['build_info'] = builds
+    release_info = {}
+    filename = [name for name in os.listdir(RELEASE_DIR) if NIGHTLY_NAME_SUFFIX in name]
+    release_info['version'] = os.path.splitext(filename[0])[0]
+    date, builds = parse_build_names(os.path.join(RELEASE_DIR, filename[0]),
+                                     release_info['version'], NIGHTLY_NAME_SUFFIX)
+    release_info['date'] = date
+    release_info['build_info'] = builds
 
-  return release_info
+    return release_info
+
 
 def get_os(build_name):
-  """
+    """
   Obtains the operating system name from a given build name.
   The osnames output as CSS classes in the 'alternative downloads' <li> in the jinja template (They are the key in the 'build_names' dict).
   This is required to allow switching of the href from the download button and the users os via JavaScript.
@@ -208,42 +228,43 @@ def get_os(build_name):
     (str,str): The name of the operating system and its type that the Mantid build will run on. Type={Linux,Windows,OSX}
     If no os can be detected (build_name,None) is returned.
   """
-  if build_name.endswith('.tar.gz') or build_name.endswith('.tar.xz'):
-    osname = "Source code"
-    ostype = "Source"
-  elif build_name.endswith('.exe'):
-    ostype = "Windows"
-    if "win32" in build_name or "windows-32bit" in build_name:
-      osname = "Windows XP 32-bit"
+    if build_name.endswith('.tar.gz') or build_name.endswith('.tar.xz'):
+        osname = "Source code"
+        ostype = "Source"
+    elif build_name.endswith('.exe'):
+        ostype = "Windows"
+        if "win32" in build_name or "windows-32bit" in build_name:
+            osname = "Windows XP 32-bit"
+        else:
+            osname = "Windows 7/8/10"
+    elif build_name.endswith(".dmg"):
+        ostype = "OSX"
+        for codename, version in iteritems(OSX_CODENAME_VERSIONS):
+            if codename in build_name:
+                osname = "OSX ({})".format(version)
     else:
-      osname = "Windows 7/8/10"
-  elif build_name.endswith(".dmg"):
-    ostype = "OSX"
-    for codename, version in iteritems(OSX_CODENAME_VERSIONS):
-      if codename in build_name:
-        osname = "OSX ({})".format(version)
-  else:
-    ostype = "Linux"
-    if "el7" in build_name:
-      osname = "Red Hat 7"
-    elif "el6" in build_name:
-      osname = "Red Hat 6"
-    elif "trusty" in build_name:
-      osname = "Ubuntu 14.04"
-    elif "xenial" in build_name:
-      osname = "Ubuntu 16.04"
-    elif "bionic" in build_name:
-      osname = "Ubuntu 18.04"
-    elif build_name.endswith(".deb"):
-      # Last debian file name without a distribution in the filename was trusty so just print "Ubuntu"
-      osname = "Ubuntu"
-    else:
-      osname = build_name
-      ostype = None
-  return osname, ostype
+        ostype = "Linux"
+        if "el7" in build_name:
+            osname = "Red Hat 7"
+        elif "el6" in build_name:
+            osname = "Red Hat 6"
+        elif "trusty" in build_name:
+            osname = "Ubuntu 14.04"
+        elif "xenial" in build_name:
+            osname = "Ubuntu 16.04"
+        elif "bionic" in build_name:
+            osname = "Ubuntu 18.04"
+        elif build_name.endswith(".deb"):
+            # Last debian file name without a distribution in the filename was trusty so just print "Ubuntu"
+            osname = "Ubuntu"
+        else:
+            osname = build_name
+            ostype = None
+    return osname, ostype
+
 
 def get_download_url(build_name, version, build_option):
-  """
+    """
   Builds a download url for a given mantid buildname.
   This is used as the value in the 'build_names' dictionary, which is output in the jinja template.
 
@@ -255,36 +276,37 @@ def get_download_url(build_name, version, build_option):
   Returns:
     str: The download url for a given build.
   """
-  if build_option is NIGHTLY_NAME_SUFFIX:
-    build_name = build_name.rstrip()
-    return SOURCEFORGE_NIGHTLY + build_name
-  elif build_option is "paraview":
-    build_name = build_name.rstrip() + "/download"
-    return SOURCEFORGE_PARAVIEW + version + "/" + build_name
-  else:
-    build_name = build_name.rstrip() + "/download"
-    pattern = "^\d\.\d+"
-    found = re.search(pattern, version)
-    return SOURCEFORGE_FILES + found.group(0) + "/" + build_name
+    if build_option is NIGHTLY_NAME_SUFFIX:
+        build_name = build_name.rstrip()
+        return SOURCEFORGE_NIGHTLY + build_name
+    elif build_option is "paraview":
+        build_name = build_name.rstrip() + "/download"
+        return SOURCEFORGE_PARAVIEW + version + "/" + build_name
+    else:
+        build_name = build_name.rstrip() + "/download"
+        pattern = "^\d\.\d+"
+        found = re.search(pattern, version)
+        return SOURCEFORGE_FILES + found.group(0) + "/" + build_name
 
 
 def get_date_from_nightly(filename):
-  """Attempts to parse a date from a nightly build file
+    """Attempts to parse a date from a nightly build file
 
   Args:
     filename (str): A string giving a filename
   """
-  match = NIGHTLY_DATE_RE.match(filename)
-  if match:
-    date = match.group(1)
-    formatted_date = "%s-%s-%s" % (date[:4], date[4:6], date[6:])
-  else:
-    raise RuntimeError("Unable to extract date from nightly build '%s'" % filename)
+    match = NIGHTLY_DATE_RE.match(filename)
+    if match:
+        date = match.group(1)
+        formatted_date = "%s-%s-%s" % (date[:4], date[4:6], date[6:])
+    else:
+        raise RuntimeError("Unable to extract date from nightly build '%s'" % filename)
 
-  return formatted_date
+    return formatted_date
+
 
 def format_release_str(release_str):
-  """
+    """
   Takes a release string, and formats it using the convention we use elsewhere
   in Mantid, for example DOI's.  Essentially, the patch number is removed if
   it is zero.  I.e. 2.1.0 becomes 2.1, 3.0.0 becomes 3.0, but 3.0 is left alone.
@@ -295,59 +317,72 @@ def format_release_str(release_str):
   Returns:
     str: the formatted release string
   """
-  if re.match("\d\.\d\.0", release_str):
-    return release_str[:-2]
-  return release_str
+    if re.match("\d\.\d\.0", release_str):
+        return release_str[:-2]
+    return release_str
+
 
 #========================================================================================================
 
 if __name__ == "__main__":
-  # Build information for each release file in the "releases" folder
-  mantid_releases = mantid_releases()
+    # Build information for each release file in the "releases" folder
+    mantid_releases = mantid_releases()
 
-  # Variables to output on the archives page
-  archive_vars = { "title" : "Mantid - Previous Releases",
-                "description" : "Downloads for current and previous releases of Mantid.",
-                "release_notes" : RELEASE_NOTES_PRE_37,
-                "releases" : mantid_releases[1:]
-                }
+    # Variables to output on the archives page
+    archive_vars = {
+        "title": "Mantid - Previous Releases",
+        "description": "Downloads for current and previous releases of Mantid.",
+        "release_notes": RELEASE_NOTES_PRE_37,
+        "releases": mantid_releases[1:]
+    }
 
-  latest_version = mantid_releases[0]
-  release_notes = RELEASE_NOTES.format(version=('v' + latest_version['mantid_version']))
-  paraview_version = mantid_releases[0]['paraview_version']
-  download_vars = { "title" : "Mantid - Downloads",
-                 "description" : "Download the latest release of Mantid.",
-                 "sample_datasets" : SAMPLES_DATASETS,
-                 "mantid_news" : MANTID_NEWS,
-                 "release_notes" : release_notes,
-                 "latest_release" : latest_version,
-                 "nightly_release" : nightly_release(),
-                 "paraview_version" : paraview_version,
-                 "paraview_build_names" : None if paraview_version is None else paraview_build_names(paraview_version),
-                 "instructions" : [os.path.splitext(filename)[0] for filename in sorted(os.listdir(INSTRUCTIONS_DIR))],
-                 "ipython_notebook" : IPYTHON_NOTEBOOK
-                 }
+    latest_version = mantid_releases[0]
+    release_notes = RELEASE_NOTES.format(version=('v' + latest_version['mantid_version']))
+    paraview_version = mantid_releases[0]['paraview_version']
+    download_vars = {
+        "title": "Mantid - Downloads",
+        "description": "Download the latest release of Mantid.",
+        "sample_datasets": SAMPLES_DATASETS,
+        "mantid_news": MANTID_NEWS,
+        "release_notes": release_notes,
+        "latest_release": latest_version,
+        "nightly_release": nightly_release(),
+        "paraview_version": paraview_version,
+        "paraview_build_names": None
+        if paraview_version is None else paraview_build_names(paraview_version),
+        "instructions": [
+            os.path.splitext(filename)[0] for filename in sorted(os.listdir(INSTRUCTIONS_DIR))
+        ],
+        "ipython_notebook": IPYTHON_NOTEBOOK
+    }
 
-  # Setup up the jinja environment and load the templates
-  env = jinja2.Environment(loader=jinja2.FileSystemLoader(searchpath=os.path.join(ROOT_DIR,"templates")))
-  # Write the contents of variables to the templates and dump the output to an HTML file.
-  env.get_template("archives.html").stream(archive_vars).dump(os.path.join(ROOT_DIR, "docs", "archives.html"))
-  env.get_template("downloads.html").stream(download_vars).dump(os.path.join(ROOT_DIR, "docs", "index.html"))
+    # Setup up the jinja environment and load the templates
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(
+        searchpath=os.path.join(ROOT_DIR, "templates")))
+    # Write the contents of variables to the templates and dump the output to an HTML file.
+    env.get_template("archives.html").stream(archive_vars).dump(
+        os.path.join(ROOT_DIR, "docs", "archives.html"))
+    env.get_template("downloads.html").stream(download_vars).dump(
+        os.path.join(ROOT_DIR, "docs", "index.html"))
 
-  for instruction_file in sorted(os.listdir(INSTRUCTIONS_DIR)):
-    with open(os.path.join(INSTRUCTIONS_DIR, instruction_file), "r") as content:
-      # Converts ReST file contents to HTML.
-      parts = docutils.core.publish_parts(
-          content.read(),
-          writer_name = 'html',
-          settings_overrides = {'doctitle_xform' : False}); # Required to disable promotion of top level header to section title.
+    for instruction_file in sorted(os.listdir(INSTRUCTIONS_DIR)):
+        with open(os.path.join(INSTRUCTIONS_DIR, instruction_file), "r") as content:
+            # Converts ReST file contents to HTML.
+            parts = docutils.core.publish_parts(content.read(),
+                                                writer_name='html',
+                                                settings_overrides={'doctitle_xform': False})
+            # Required to disable promotion of top level header to section title.
 
-      # Remove extension from instruction filename
-      filename = os.path.splitext(instruction_file)[0]
-      filename = filename.replace("-"," ")
+            # Remove extension from instruction filename
+            filename = os.path.splitext(instruction_file)[0]
+            filename = filename.replace("-", " ")
 
-      instruction_vars = {"title" : filename + " installation instructions for Mantid.",
-                         "description" : "Mantid installation instructions for " + filename + ".",
-                         "instructions" : parts["html_body"]}
+            instruction_vars = {
+                "title": filename + " installation instructions for Mantid.",
+                "description": "Mantid installation instructions for " + filename + ".",
+                "instructions": parts["html_body"]
+            }
 
-      env.get_template("instructions.html").stream(instruction_vars).dump(os.path.join(ROOT_DIR, "docs", filename.replace(" ", "").lower() + ".html"))
+            env.get_template("instructions.html").stream(instruction_vars).dump(
+                os.path.join(ROOT_DIR, "docs",
+                             filename.replace(" ", "").lower() + ".html"))

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -49,7 +49,13 @@ IPYTHON_NOTEBOOK = [
   ["IPython Notebook Example", SOURCEFORGE_IPYTHON_NOTEBOOK + "Introduction%20to%20using%20Mantid%20with%20IPython%20Notebook.ipynb/download" ]
 ]
 
-OSX_CODENAME_VERSIONS = {'SnowLeopard': '10.6', 'Lion': '10.7', 'MountainLion': '10.8', 'Mavericks': '10.9', 'Yosemite': '10.10', 'ElCapitan': '10.11'}
+OSX_CODENAME_VERSIONS = {
+  'SnowLeopard': '10.6', 'Lion': '10.7',
+  'MountainLion': '10.8', 'Mavericks': '10.9',
+  'Yosemite': '10.10', 'ElCapitan': '10.11',
+  'Sierra': '10.12', 'HighSierra': '10.13',
+  'Mojave': '10.14', 'Catalina': '10.15'
+}
 
 def mantid_releases():
   """

--- a/tools/create-manifest.py
+++ b/tools/create-manifest.py
@@ -12,7 +12,7 @@ import sys
 # TODO: Update list if a build name changes with a release.
 MANTID_BUILD_NAMES = [
   "mantid%s-%s-win64.exe",
-  "mantid%s-%s-Yosemite.dmg",
+  "mantid%s-%s-HighSierra.dmg",
   "mantid%s-%s-1.el7.x86_64.rpm",
   "mantid%s_%s-0ubuntu1~xenial1_amd64.deb",
   "mantid%s_%s-0ubuntu1~bionic1_amd64.deb",
@@ -22,7 +22,7 @@ MANTID_BUILD_NAMES = [
 TIMESTAMP_RE = r'\d+.\d+.\d{8}.\d+'
 NIGHTLY_BUILD_REGEXES = [
   "mantidnightly-{0}-win64.exe".format(TIMESTAMP_RE),
-  "mantid-{0}-Yosemite.dmg".format(TIMESTAMP_RE),
+  "mantid-{0}-HighSierra.dmg".format(TIMESTAMP_RE),
   "mantidnightly-{0}-1.el7.x86_64.rpm".format(TIMESTAMP_RE),
   "mantidnightly_{0}-0ubuntu1~(?:\w+)1_amd64.deb".format(TIMESTAMP_RE),
   "mantidnightly-{0}-Source.tar.xz".format(TIMESTAMP_RE)

--- a/tools/create-manifest.py
+++ b/tools/create-manifest.py
@@ -11,34 +11,30 @@ import sys
 
 # TODO: Update list if a build name changes with a release.
 MANTID_BUILD_NAMES = [
-  "mantid%s-%s-win64.exe",
-  "mantid%s-%s-HighSierra.dmg",
-  "mantid%s-%s-1.el7.x86_64.rpm",
-  "mantid%s_%s-0ubuntu1~xenial1_amd64.deb",
-  "mantid%s_%s-0ubuntu1~bionic1_amd64.deb",
-  "mantid%s-%s-Source.tar.xz"
+    "mantid%s-%s-win64.exe", "mantid%s-%s-HighSierra.dmg", "mantid%s-%s-1.el7.x86_64.rpm",
+    "mantid%s_%s-0ubuntu1~xenial1_amd64.deb", "mantid%s_%s-0ubuntu1~bionic1_amd64.deb",
+    "mantid%s-%s-Source.tar.xz"
 ]
 
 TIMESTAMP_RE = r'\d+.\d+.\d{8}.\d+'
 NIGHTLY_BUILD_REGEXES = [
-  "mantidnightly-{0}-win64.exe".format(TIMESTAMP_RE),
-  "mantid-{0}-HighSierra.dmg".format(TIMESTAMP_RE),
-  "mantidnightly-{0}-1.el7.x86_64.rpm".format(TIMESTAMP_RE),
-  "mantidnightly_{0}-0ubuntu1~(?:\w+)1_amd64.deb".format(TIMESTAMP_RE),
-  "mantidnightly-{0}-Source.tar.xz".format(TIMESTAMP_RE)
+    "mantidnightly-{0}-win64.exe".format(TIMESTAMP_RE),
+    "mantid-{0}-HighSierra.dmg".format(TIMESTAMP_RE),
+    "mantidnightly-{0}-1.el7.x86_64.rpm".format(TIMESTAMP_RE),
+    "mantidnightly_{0}-0ubuntu1~(?:\w+)1_amd64.deb".format(TIMESTAMP_RE),
+    "mantidnightly-{0}-Source.tar.xz".format(TIMESTAMP_RE)
 ]
 
 # TODO: Update if a paraview build name changes with a new supported release.
 PARAVIEW_BUILD_NAMES = [
-  "ParaView-%s-Windows-64bit.exe",
-  "ParaView-%s-Windows-32bit.exe",
-  "ParaView-%s-SnowLeopard-64bit.dmg",
-  "ParaView-%s-MountainLion-64bit.dmg",
-  "ParaView-%s-Linux-64bit.tar.gz",
-  "ParaView-%s-source.tar.gz"]
+    "ParaView-%s-Windows-64bit.exe", "ParaView-%s-Windows-32bit.exe",
+    "ParaView-%s-SnowLeopard-64bit.dmg", "ParaView-%s-MountainLion-64bit.dmg",
+    "ParaView-%s-Linux-64bit.tar.gz", "ParaView-%s-source.tar.gz"
+]
+
 
 def update_paraview_versions(mantid_version, paraview_version):
-  """
+    """
   Adds the mantid release code and paraview version to the top of the paraviewReleases file.
   If paraview_version is greater than previous paraview version a new paraview build file is created.
 
@@ -46,23 +42,26 @@ def update_paraview_versions(mantid_version, paraview_version):
     mantid_version (str): The version number of the given Mantid release.
     paraview_version (str): The paraview version that this release of Mantid will use.
   """
-  with open(os.path.join(PARAVIEW_DIR, "paraviewVersions.txt"), "r+") as paraview_versions:
-    # Read entire file to enable insertion to start of file.
-    content = paraview_versions.read()
-    # If no paraview version is provided, then the previous paraview version is used.
-    previous_version = content.split("\n",1)[0].split(",")[1]
-    if not paraview_version:
-      paraview_version = previous_version
-    # Add the new release and paraview version to the top of the file
-    paraview_versions.seek(0,0)
-    paraview_versions.write(mantid_version + "," + paraview_version + "\n" + content)
-    print("The following was added to the paraviewVersions file: " + mantid_version + " " + paraview_version)
-    # Compare paraview versions, and create a new ('latest') paraview file if provided version is greater than previous
-    if distutils.version.StrictVersion(paraview_version) > distutils.version.StrictVersion(previous_version):
-      create_paraview_file(paraview_version)
+    with open(os.path.join(PARAVIEW_DIR, "paraviewVersions.txt"), "r+") as paraview_versions:
+        # Read entire file to enable insertion to start of file.
+        content = paraview_versions.read()
+        # If no paraview version is provided, then the previous paraview version is used.
+        previous_version = content.split("\n", 1)[0].split(",")[1]
+        if not paraview_version:
+            paraview_version = previous_version
+        # Add the new release and paraview version to the top of the file
+        paraview_versions.seek(0, 0)
+        paraview_versions.write(mantid_version + "," + paraview_version + "\n" + content)
+        print("The following was added to the paraviewVersions file: " + mantid_version + " " +
+              paraview_version)
+        # Compare paraview versions, and create a new ('latest') paraview file if provided version is greater than previous
+        if distutils.version.StrictVersion(paraview_version) > distutils.version.StrictVersion(
+                previous_version):
+            create_paraview_file(paraview_version)
+
 
 def create_release_file(version, date, overwrite):
-  """
+    """
   Creates a file in the release folder and writes the build names to it for a given release.
 
   Args:
@@ -70,19 +69,21 @@ def create_release_file(version, date, overwrite):
     date (str): The date that this version of Mantid was released.
     overwrite (bool): If true, overwrite a file if it already exists
   """
-  filename = version + ".txt"
-  filepath = os.path.join(RELEASE_DIR, version + ".txt")
-  if os.path.exists(filepath) and not overwrite:
-    raise RuntimeError("File '%s' already exists, use --force to overwrite." % filename)
+    filename = version + ".txt"
+    filepath = os.path.join(RELEASE_DIR, version + ".txt")
+    if os.path.exists(filepath) and not overwrite:
+        raise RuntimeError("File '%s' already exists, use --force to overwrite." % filename)
 
-  suffix = ""
-  with open(filepath, "w") as release_file:
-    release_file.write(date + "\n\n")
-    release_file.write('\n'.join([build_name % (suffix, version) for build_name in MANTID_BUILD_NAMES]))
-    print("New release manifest created in releases directory: %s" % (version + ".txt"))
+    suffix = ""
+    with open(filepath, "w") as release_file:
+        release_file.write(date + "\n\n")
+        release_file.write('\n'.join(
+            [build_name % (suffix, version) for build_name in MANTID_BUILD_NAMES]))
+        print("New release manifest created in releases directory: %s" % (version + ".txt"))
+
 
 def create_nightly_file(nightly_package_dir):
-  """
+    """
   Creates a file in the release folder called nightly.txt that contains the current package versions
   for the nightly builds
 
@@ -90,109 +91,129 @@ def create_nightly_file(nightly_package_dir):
     nightly_package_dir (str): A directory containing new nightly build packages. The existing file is
                                only *updated* with packages
   """
-  filepath = os.path.join(RELEASE_DIR, "nightly.txt")
-  current_packages = create_current_nightly_package_list(filepath)
-  updated_packages = create_updated_package_list(nightly_package_dir)
-  if len(updated_packages) == 0:
-    raise RuntimeError("No nightly packages found in '{0}'".format(nightly_package_dir))
+    filepath = os.path.join(RELEASE_DIR, "nightly.txt")
+    current_packages = create_current_nightly_package_list(filepath)
+    updated_packages = create_updated_package_list(nightly_package_dir)
+    if len(updated_packages) == 0:
+        raise RuntimeError("No nightly packages found in '{0}'".format(nightly_package_dir))
 
-  # filter out those from current list that have no updated version
-  def no_update(filename):
-    for updated in updated_packages:
-      for build_re_str in NIGHTLY_BUILD_REGEXES:
-        build_re = re.compile(build_re_str)
-        if build_re.match(filename) and build_re.match(updated):
-          return False
-    return True
-  #end
-  nightlies = list(filter(no_update, current_packages))
-  nightlies.extend(updated_packages)
-  nightlies.sort()
-  open(filepath, 'w').write("\n".join(nightlies))
+    # filter out those from current list that have no updated version
+    def no_update(filename):
+        for updated in updated_packages:
+            for build_re_str in NIGHTLY_BUILD_REGEXES:
+                build_re = re.compile(build_re_str)
+                if build_re.match(filename) and build_re.match(updated):
+                    return False
+        return True
+
+    #end
+    nightlies = list(filter(no_update, current_packages))
+    nightlies.extend(updated_packages)
+    nightlies.sort()
+    open(filepath, 'w').write("\n".join(nightlies))
+
 
 def create_current_nightly_package_list(manifest_filename):
-  """
+    """
   Create a list of builds/source files that are current listed in the nightly section
 
   Args:
     manifest_filename (str): A file path pointing to the manifest for the current nightly build
   """
-  if os.path.exists(manifest_filename):
-    file_contents = open(manifest_filename).read()
-    current_packages = file_contents.strip().split("\n")
-  else:
-    current_packages = []
+    if os.path.exists(manifest_filename):
+        file_contents = open(manifest_filename).read()
+        current_packages = file_contents.strip().split("\n")
+    else:
+        current_packages = []
 
-  return current_packages
+    return current_packages
+
 
 def create_updated_package_list(nightly_package_dir):
-  """
+    """
   Create a list of builds/source files for the page
 
   Args:
     nightly_package_dir (str): A directory path to list for nightly packages
   """
-  if not os.path.exists(nightly_package_dir):
-    raise RuntimeError("Invalid directory for nightly build artifacts '{0}'".format(nightly_package_dir))
-  updated_packages = os.listdir(nightly_package_dir)
+    if not os.path.exists(nightly_package_dir):
+        raise RuntimeError(
+            "Invalid directory for nightly build artifacts '{0}'".format(nightly_package_dir))
+    updated_packages = os.listdir(nightly_package_dir)
 
-  def is_binary_or_source(item):
-    for build_re_str in NIGHTLY_BUILD_REGEXES:
-      build_re = re.compile(build_re_str)
-      if build_re.match(item):
-        return True
-    return False
-  #end
-  return list(filter(is_binary_or_source, updated_packages))
+    def is_binary_or_source(item):
+        for build_re_str in NIGHTLY_BUILD_REGEXES:
+            build_re = re.compile(build_re_str)
+            if build_re.match(item):
+                return True
+        return False
+
+    #end
+    return list(filter(is_binary_or_source, updated_packages))
+
 
 def create_paraview_file(version):
-  """
+    """
   Creates a new paraview build file in the paraview folder with a given version name.
 
   Args:
     version (str): Used to name the file, and name the builds within the file.
   """
-  with open(os.path.join(PARAVIEW_DIR, "paraview-" + version + ".txt"), "w+") as release_file:
-    release_file.write('\n'.join([build_name%(version) for build_name in PARAVIEW_BUILD_NAMES]))
+    with open(os.path.join(PARAVIEW_DIR, "paraview-" + version + ".txt"), "w+") as release_file:
+        release_file.write('\n'.join(
+            [build_name % (version) for build_name in PARAVIEW_BUILD_NAMES]))
+
 
 if __name__ == "__main__":
 
-  RELEASE_DIR = os.path.join(os.path.dirname(__file__), "..", "releases")
-  PARAVIEW_DIR = os.path.join(RELEASE_DIR, "paraview")
+    RELEASE_DIR = os.path.join(os.path.dirname(__file__), "..", "releases")
+    PARAVIEW_DIR = os.path.join(RELEASE_DIR, "paraview")
 
-  parser = argparse.ArgumentParser(prog='create-manifest', usage='%(prog)s [options]',
-      description='Creates a release file in the "releases" folder with the name provided.')
-  parser.add_argument('version',
-                      help="The version of the release to name the file being saved in the 'releases' folder.")
-  parser.add_argument('--force', action='store_true', # defaults to false
-                      help="Overwrite any existing file")
-  parser.add_argument('--date',
-                      help="The date of the release. This option overrides the current date, which is used by default.")
-  parser.add_argument('--paraview',
-                      help="The version of paraview for the release. Uses the previous version if not changed.")
-  parser.add_argument('--dir', default="artifacts",
-                      help="If provided then look in this directory for night build packages")
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        prog='create-manifest',
+        usage='%(prog)s [options]',
+        description='Creates a release file in the "releases" folder with the name provided.')
+    parser.add_argument(
+        'version',
+        help="The version of the release to name the file being saved in the 'releases' folder.")
+    parser.add_argument(
+        '--force',
+        action='store_true',  # defaults to false
+        help="Overwrite any existing file")
+    parser.add_argument(
+        '--date',
+        help=
+        "The date of the release. This option overrides the current date, which is used by default."
+    )
+    parser.add_argument(
+        '--paraview',
+        help="The version of paraview for the release. Uses the previous version if not changed.")
+    parser.add_argument('--dir',
+                        default="artifacts",
+                        help="If provided then look in this directory for night build packages")
+    args = parser.parse_args()
 
-  # Validate version
-  version_pattern = re.compile("^\d\.\d+\.\d+$")
-  has_correct_version = version_pattern.match(args.version) is not None
-  if args.version != "nightly" and not has_correct_version:
-    sys.exit("Error: Invalid version number provided. The format expected is X.Y.Z or the word 'nightly'")
+    # Validate version
+    version_pattern = re.compile("^\d\.\d+\.\d+$")
+    has_correct_version = version_pattern.match(args.version) is not None
+    if args.version != "nightly" and not has_correct_version:
+        sys.exit(
+            "Error: Invalid version number provided. The format expected is X.Y.Z or the word 'nightly'"
+        )
 
-  if args.version == "nightly":
-    create_nightly_file(os.path.join(os.path.dirname(__file__), args.dir))
-  else:
-    # Use current date if none provided
-    if not args.date:
-      args.date = datetime.date.today()
+    if args.version == "nightly":
+        create_nightly_file(os.path.join(os.path.dirname(__file__), args.dir))
     else:
-      # Validate the date provided is the correct format.
-      try:
-        datetime.datetime.strptime(args.date, "%Y-%m-%d")
-      except ValueError:
-        sys.exit("The date you have provided is invalid. It must be in Y-M-D format.")
-    #
-    create_release_file(args.version,str(args.date), args.force)
-    if args.paraview:
-      update_paraview_versions(args.version,args.paraview)
+        # Use current date if none provided
+        if not args.date:
+            args.date = datetime.date.today()
+        else:
+            # Validate the date provided is the correct format.
+            try:
+                datetime.datetime.strptime(args.date, "%Y-%m-%d")
+            except ValueError:
+                sys.exit("The date you have provided is invalid. It must be in Y-M-D format.")
+        #
+        create_release_file(args.version, str(args.date), args.force)
+        if args.paraview:
+            update_paraview_versions(args.version, args.paraview)


### PR DESCRIPTION
The manifest creation tool now creates a HighSierra link
for macOS. The build tool now understands that HighSierra
and future macOS versions exist. See mantidproject/mantid#26866