### PR TITLE
Initial implementation of new conda installs

### DIFF
--- a/docs/conda.html
+++ b/docs/conda.html
@@ -14,34 +14,45 @@
 <body>
 
 <div class="document">
-<div class="section" id="install-mantid-framework-only-using-conda">
-<h1>Install mantid (framework-only) using conda</h1>
-<p>Note that this is an unofficial distribution channel and not suitable for production use.
-It may not work as described and may disappear with little notice.</p>
+<div class="section" id="install-mantid-mantidqt-or-mantidworkbench-using-conda">
+<h1>Install mantid, mantidqt, or mantidworkbench using conda</h1>
 <p>Supported platforms:</p>
 <ul class="simple">
-<li>Linux-64: latest ubuntu/fedora/redhat (see below for distribution-specific instructions)</li>
-<li>Mac OS X: experimental</li>
+<li>Linux-64: available for 64-bit Linux distributions (tested for Ubuntu and CentOS/RHEL).</li>
+<li>Mac OS X: available for all MacOS versions 10.10 and higher.</li>
+<li>Windows: available for windows 10 and higher.</li>
 </ul>
-<p>Installation:</p>
+<p>You need to have a version of conda already installed, we recommend using <a class="reference external" href="https://github.com/conda-forge/miniforge/releases">mambaforge</a>. As it adds support for <a class="reference external" href="https://conda-forge.org/">conda-forge</a>
+channels by default, and allows users to by default, use mamba (replace <cite>conda</cite> with <cite>mamba</cite> in commands to use it), which is a faster version of conda for creating
+<a class="reference external" href="https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html">conda environments</a>.</p>
+<p>If not using mambaforge, add conda-forge to your channels:</p>
 <pre class="literal-block">
-$ conda config --add channels conda-forge      # add conda-forge channel
-$ conda install -c mantid mantid-framework     # install
+$ conda config --add channels conda-forge
 </pre>
-<p>To install the nightly build:</p>
+<p>Installing latest release version of mantid:</p>
 <pre class="literal-block">
-$ conda install -c mantid/label/nightly mantid-framework
+$ conda install mantid -c mantid
 </pre>
-<div class="section" id="ubuntu">
-<h2>Ubuntu</h2>
-<p>A caveat for using conda build of mantid-framework at an ubuntu distribution is
-that you will need to import matplotlib before mantid to get the correct backend
-initialized:</p>
+<p>Installing latest release version of mantidqt:</p>
 <pre class="literal-block">
-import matplotlib
-import mantid
+$ conda install mantidqt -c mantid
 </pre>
-</div>
+<p>Installing latest release version of mantidworkbench:</p>
+<pre class="literal-block">
+$ conda install mantidworkbench -c mantid
+</pre>
+<p>To install the nightly build of mantid:</p>
+<pre class="literal-block">
+$ conda install mantid -c mantid/label/nightly
+</pre>
+<p>To install the nightly build of mantidqt:</p>
+<pre class="literal-block">
+$ conda install mantidqt -c mantid/label/nightly
+</pre>
+<p>To install the nightly build of mantidworkbench:</p>
+<pre class="literal-block">
+$ conda install mantidworkbench -c mantid/label/nightly
+</pre>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,17 @@
     </ul>
     <a href="./archives.html" id="previous">Previous releases</a>
   </section>
+  <section id="conda" class="wrapper">
+    <h2>Conda packages</h2>
+    <p>Mantid is available in a number of <a href="https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html">conda</a> packages via anaconda.org on the <a href="https://anaconda.org/mantid">mantid channel</a>.</p>
+    <p>The following packages are available:</p>
+    <ul>
+      <li><a href="https://anaconda.org/mantid/mantid">mantid</a>: for those who want mantid's core capabilities, including algorithms and workspaces, availiable via python</li>
+      <li><a href="https://anaconda.org/mantid/mantidqt">mantidqt</a>: for those who want mantid interfaces availiable via python</li>
+      <li><a href="https://anaconda.org/mantid/mantidworkbench">mantidworkbench</a>: for those who want the fully fledged mantid experience including the workbench GUI</li>
+    </ul>
+    <p><a href="./conda.html">how to install mantid with conda</a></p>
+  </section>
     <section id="gridcontainer">
       <article id="samples" class="column">
         <h2>Sample Datasets</h2>

--- a/instructions/conda.rst
+++ b/instructions/conda.rst
@@ -1,31 +1,42 @@
-===========================================
-Install mantid (framework-only) using conda
-===========================================
-
-Note that this is an unofficial distribution channel and not suitable for production use.
-It may not work as described and may disappear with little notice.
+========================================================
+Install mantid, mantidqt, or mantidworkbench using conda
+========================================================
 
 Supported platforms:
 
-* Linux-64: latest ubuntu/fedora/redhat (see below for distribution-specific instructions)
-* Mac OS X: experimental
+* Linux-64: available for 64-bit Linux distributions (tested for Ubuntu and CentOS/RHEL).
+* Mac OS X: available for all MacOS versions 10.10 and higher.
+* Windows: available for windows 10 and higher.
 
-Installation::
+You need to have a version of conda already installed, we recommend using `mambaforge <https://github.com/conda-forge/miniforge/releases>`_. As it adds support for `conda-forge <https://conda-forge.org/>`_
+channels by default, and allows users to by default, use mamba (replace `conda` with `mamba` in commands to use it), which is a faster version of conda for creating 
+`conda environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_.
 
-  $ conda config --add channels conda-forge      # add conda-forge channel
-  $ conda install -c mantid mantid-framework     # install
+If not using mambaforge, add conda-forge to your channels::
 
+  $ conda config --add channels conda-forge 
 
-To install the nightly build::
+Installing latest release version of mantid::
 
-  $ conda install -c mantid/label/nightly mantid-framework
+  $ conda install mantid -c mantid
 
-Ubuntu
-------
+Installing latest release version of mantidqt::
 
-A caveat for using conda build of mantid-framework at an ubuntu distribution is
-that you will need to import matplotlib before mantid to get the correct backend
-initialized::
+  $ conda install mantidqt -c mantid 
 
-  import matplotlib
-  import mantid
+Installing latest release version of mantidworkbench::
+
+  $ conda install mantidworkbench -c mantid
+
+To install the nightly build of mantid::
+
+  $ conda install mantid -c mantid/label/nightly
+
+To install the nightly build of mantidqt::
+
+  $ conda install mantidqt -c mantid/label/nightly
+
+To install the nightly build of mantidworkbench::
+
+  $ conda install mantidworkbench -c mantid/label/nightly
+

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -33,6 +33,17 @@
     </ul>
     <a href="./archives.html" id="previous">Previous releases</a>
   </section>
+  <section id="conda" class="wrapper">
+    <h2>Conda packages</h2>
+    <p>Mantid is available in a number of <a href="https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html">conda</a> packages via anaconda.org on the <a href="https://anaconda.org/mantid">mantid channel</a>.</p>
+    <p>The following packages are available:</p>
+    <ul>
+      <li><a href="https://anaconda.org/mantid/mantid">mantid</a>: for those who want mantid's core capabilities, including algorithms and workspaces, availiable via python</li>
+      <li><a href="https://anaconda.org/mantid/mantidqt">mantidqt</a>: for those who want mantid interfaces availiable via python</li>
+      <li><a href="https://anaconda.org/mantid/mantidworkbench">mantidworkbench</a>: for those who want the fully fledged mantid experience including the workbench GUI</li>
+    </ul>
+    <p><a href="./conda.html">how to install mantid with conda</a></p>
+  </section>
     <section id="gridcontainer">
       <article id="samples" class="column">
         <h2>Sample Datasets</h2>


### PR DESCRIPTION
For merger shortly before, or just after conda packages have been uploaded for both nightly and release of v6.3