### PR TITLE
Fix OS handling tests

### DIFF
--- a/tools/impl/os_handling.py
+++ b/tools/impl/os_handling.py
@@ -29,8 +29,8 @@ def get_osx_codename(filename: str) -> str:
     ]
 
     if not found_version:
+        # Assume that this is a conda-build that supports 10.9+
         return "10.9"
-        #raise KeyError(f"No known releases for {filename}")
 
     return found_version[-1]
 

--- a/tools/tests/test_os_handling.py
+++ b/tools/tests/test_os_handling.py
@@ -17,9 +17,8 @@ def test_between_high_sierra_and_sierra():
     assert os_handling.get_osx_codename("HighSierra") == "10.13"
 
 
-def test_invalid_codename_throws():
-    with pytest.raises(KeyError):
-        os_handling.get_osx_codename("Unknown")
+def test_missing_codename_returns_10_9():
+    assert os_handling.get_osx_codename("Unknown") == "10.9"
 
 
 @pytest.mark.parametrize("filename, expected",


### PR DESCRIPTION
New conda builds come without a platform as they support many versions with a minimum 10.9. We now assume 10.9 if no platform marker is found.

**To test**

Review changes and see tests now pass.

Fixes #34 